### PR TITLE
OpenSynchronos rebrand + IPC compatibility layer + Moodles V2 + ImageSharp security update

### DIFF
--- a/OpenSynchronos/FileCache/CacheMonitor.cs
+++ b/OpenSynchronos/FileCache/CacheMonitor.cs
@@ -1,4 +1,4 @@
-﻿using OpenSynchronos.Utils;
+using OpenSynchronos.Utils;
 using Microsoft.Extensions.Logging;
 using OpenSynchronos.Interop.Ipc;
 using OpenSynchronos.MareConfiguration;
@@ -121,7 +121,7 @@ public sealed class CacheMonitor : DisposableMediatorSubscriberBase
         if (string.IsNullOrEmpty(marePath) || !Directory.Exists(marePath))
         {
             MareWatcher = null;
-            Logger.LogWarning("OpenSynchronos file path is not set, cannot start the FSW for Mare.");
+            Logger.LogWarning("OpenSynchronos file path is not set, cannot start the FSW for OpenSynchronos.");
             return;
         }
 

--- a/OpenSynchronos/GlobalSuppressions.cs
+++ b/OpenSynchronos/GlobalSuppressions.cs
@@ -5,4 +5,4 @@
 
 using System.Diagnostics.CodeAnalysis;
 
-[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>", Scope = "member", Target = "~M:MareSynchronos.Services.CharaDataManager.AttachPoseData(OpenSynchronos.API.Dto.CharaData.PoseEntry,MareSynchronos.Services.CharaData.Models.CharaDataExtendedUpdateDto)")]
+[assembly: SuppressMessage("Interoperability", "CA1416:Validate platform compatibility", Justification = "<Pending>", Scope = "member", Target = "~M:OpenSynchronos.Services.CharaDataManager.AttachPoseData(OpenSynchronos.API.Dto.CharaData.PoseEntry,OpenSynchronos.Services.CharaData.Models.CharaDataExtendedUpdateDto)")]

--- a/OpenSynchronos/Interop/Ipc/IpcCallerGlamourer.cs
+++ b/OpenSynchronos/Interop/Ipc/IpcCallerGlamourer.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Plugin;
 using Glamourer.Api.Helpers;
 using Glamourer.Api.IpcSubscribers;
@@ -97,7 +97,7 @@ public sealed class IpcCallerGlamourer : DisposableMediatorSubscriberBase, IIpcC
             if (!apiAvailable && !_shownGlamourerUnavailable)
             {
                 _shownGlamourerUnavailable = true;
-                _mareMediator.Publish(new NotificationMessage("Glamourer inactive", "Your Glamourer installation is not active or out of date. Update Glamourer to continue to use Mare. If you just updated Glamourer, ignore this message.",
+                _mareMediator.Publish(new NotificationMessage("Glamourer inactive", "Your Glamourer installation is not active or out of date. Update Glamourer to continue to use OpenSynchronos. If you just updated Glamourer, ignore this message.",
                     NotificationType.Error));
             }
         }

--- a/OpenSynchronos/Interop/Ipc/IpcCallerMoodles.cs
+++ b/OpenSynchronos/Interop/Ipc/IpcCallerMoodles.cs
@@ -27,9 +27,10 @@ public sealed class IpcCallerMoodles : IIpcCaller
 
         _moodlesApiVersion = pi.GetIpcSubscriber<int>("Moodles.Version");
         _moodlesOnChange = pi.GetIpcSubscriber<IPlayerCharacter, object>("Moodles.StatusManagerModified");
-        _moodlesGetStatus = pi.GetIpcSubscriber<nint, string>("Moodles.GetStatusManagerByPtr");
-        _moodlesSetStatus = pi.GetIpcSubscriber<nint, string, object>("Moodles.SetStatusManagerByPtr");
-        _moodlesRevertStatus = pi.GetIpcSubscriber<nint, object>("Moodles.ClearStatusManagerByPtr");
+        // Moodles v3 IPC renamed ByPtr endpoints to *ByPtrV2; use the V2 labels
+        _moodlesGetStatus = pi.GetIpcSubscriber<nint, string>("Moodles.GetStatusManagerByPtrV2");
+        _moodlesSetStatus = pi.GetIpcSubscriber<nint, string, object>("Moodles.SetStatusManagerByPtrV2");
+        _moodlesRevertStatus = pi.GetIpcSubscriber<nint, object>("Moodles.ClearStatusManagerByPtrV2");
 
         _moodlesOnChange.Subscribe(OnMoodlesChange);
 
@@ -47,7 +48,8 @@ public sealed class IpcCallerMoodles : IIpcCaller
     {
         try
         {
-            APIAvailable = _moodlesApiVersion.InvokeFunc() == 1;
+            // Moodles IPC Version >= 2 supports the *ByPtrV2 endpoints we use
+            APIAvailable = _moodlesApiVersion.InvokeFunc() >= 2;
         }
         catch
         {

--- a/OpenSynchronos/Interop/Ipc/IpcCallerPenumbra.cs
+++ b/OpenSynchronos/Interop/Ipc/IpcCallerPenumbra.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Plugin;
+using Dalamud.Plugin;
 using Microsoft.Extensions.Logging;
 using OpenSynchronos.MareConfiguration.Models;
 using OpenSynchronos.PlayerData.Handlers;
@@ -126,7 +126,7 @@ public sealed class IpcCallerPenumbra : DisposableMediatorSubscriberBase, IIpcCa
             {
                 _shownPenumbraUnavailable = true;
                 _mareMediator.Publish(new NotificationMessage("Penumbra inactive",
-                    "Your Penumbra installation is not active or out of date. Update Penumbra and/or the Enable Mods setting in Penumbra to continue to use Mare. If you just updated Penumbra, ignore this message.",
+                    "Your Penumbra installation is not active or out of date. Update Penumbra and/or the Enable Mods setting in Penumbra to continue to use OpenSynchronos. If you just updated Penumbra, ignore this message.",
                     NotificationType.Error));
             }
         }

--- a/OpenSynchronos/Interop/Ipc/IpcProvider.cs
+++ b/OpenSynchronos/Interop/Ipc/IpcProvider.cs
@@ -17,6 +17,10 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
     private ICallGateProvider<string, IGameObject, bool>? _loadFileProvider;
     private ICallGateProvider<string, IGameObject, Task<bool>>? _loadFileAsyncProvider;
     private ICallGateProvider<List<nint>>? _handledGameAddresses;
+    // New IPC labels under OpenSynchronos for rebrand, keep both for compatibility
+    private ICallGateProvider<string, IGameObject, bool>? _loadFileProviderOs;
+    private ICallGateProvider<string, IGameObject, Task<bool>>? _loadFileAsyncProviderOs;
+    private ICallGateProvider<List<nint>>? _handledGameAddressesOs;
     private readonly List<GameObjectHandler> _activeGameObjectHandlers = [];
 
     public MareMediator Mediator { get; init; }
@@ -50,6 +54,14 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
         _loadFileAsyncProvider.RegisterFunc(LoadMcdfAsync);
         _handledGameAddresses = _pi.GetIpcProvider<List<nint>>("MareSynchronos.GetHandledAddresses");
         _handledGameAddresses.RegisterFunc(GetHandledAddresses);
+
+        // Register new OpenSynchronos IPC endpoints
+        _loadFileProviderOs = _pi.GetIpcProvider<string, IGameObject, bool>("OpenSynchronos.LoadMcdf");
+        _loadFileProviderOs.RegisterFunc(LoadMcdf);
+        _loadFileAsyncProviderOs = _pi.GetIpcProvider<string, IGameObject, Task<bool>>("OpenSynchronos.LoadMcdfAsync");
+        _loadFileAsyncProviderOs.RegisterFunc(LoadMcdfAsync);
+        _handledGameAddressesOs = _pi.GetIpcProvider<List<nint>>("OpenSynchronos.GetHandledAddresses");
+        _handledGameAddressesOs.RegisterFunc(GetHandledAddresses);
         _logger.LogInformation("Started IpcProviderService");
         return Task.CompletedTask;
     }
@@ -60,6 +72,9 @@ public class IpcProvider : IHostedService, IMediatorSubscriber
         _loadFileProvider?.UnregisterFunc();
         _loadFileAsyncProvider?.UnregisterFunc();
         _handledGameAddresses?.UnregisterFunc();
+        _loadFileProviderOs?.UnregisterFunc();
+        _loadFileAsyncProviderOs?.UnregisterFunc();
+        _handledGameAddressesOs?.UnregisterFunc();
         Mediator.UnsubscribeAll(this);
         return Task.CompletedTask;
     }

--- a/OpenSynchronos/OpenSynchronos.csproj
+++ b/OpenSynchronos/OpenSynchronos.csproj
@@ -28,7 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="12.0.0" />
     <PackageReference Include="Downloader" Version="3.3.4" />
     <PackageReference Include="K4os.Compression.LZ4.Legacy" Version="1.3.8" />
     <PackageReference Include="Meziantou.Analyzer" Version="2.0.189">
@@ -42,7 +41,7 @@
     <PackageReference Include="NReco.Logging.File" Version="1.2.2" />
     <PackageReference Include="Penumbra.Api" Version="5.12.0" />
     <PackageReference Include="Penumbra.String" Version="1.0.5" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.11" />
     <PackageReference Include="SonarAnalyzer.CSharp" Version="10.7.0.110445">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/OpenSynchronos/Plugin.cs
+++ b/OpenSynchronos/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.Objects;
+using Dalamud.Game.ClientState.Objects;
 using Dalamud.Interface.ImGuiFileDialog;
 using Dalamud.Interface.Windowing;
 using Dalamud.Plugin;
@@ -76,8 +76,8 @@ public sealed class Plugin : IDalamudPlugin
         {
             lb.ClearProviders();
             lb.AddDalamudLogging(pluginLog, gameData.HasModifiedGameDataFiles);
-            lb.AddFile(Path.Combine(traceDir, $"mare-trace-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.log"), (opt) =>
-            {
+            lb.AddFile(Path.Combine(traceDir, $"opensynchronos-trace-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}.log"), (opt) =>
+                {
                 opt.Append = true;
                 opt.RollingFilesConvention = FileLoggerOptions.FileRollingConvention.Ascending;
                 opt.MinLevel = LogLevel.Trace;
@@ -87,9 +87,9 @@ public sealed class Plugin : IDalamudPlugin
         })
         .ConfigureServices(collection =>
         {
-            collection.AddSingleton(new WindowSystem("MareSynchronos"));
+            collection.AddSingleton(new WindowSystem("OpenSynchronos"));
             collection.AddSingleton<FileDialogManager>();
-            collection.AddSingleton(new Dalamud.Localization("MareSynchronos.Localization.", "", useEmbedded: true));
+            collection.AddSingleton(new Dalamud.Localization("OpenSynchronos.Localization.", "", useEmbedded: true));
 
             // add mare related singletons
             collection.AddSingleton<MareMediator>();
@@ -168,7 +168,7 @@ public sealed class Plugin : IDalamudPlugin
             {
                 var httpClient = new HttpClient();
                 var ver = Assembly.GetExecutingAssembly().GetName().Version;
-                httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("MareSynchronos", ver!.Major + "." + ver!.Minor + "." + ver!.Build));
+                httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OpenSynchronos", ver!.Major + "." + ver!.Minor + "." + ver!.Build));
                 return httpClient;
             });
             collection.AddSingleton((s) => new MareConfigService(pluginInterface.ConfigDirectory.FullName));

--- a/OpenSynchronos/Services/CharaData/CharaDataFileHandler.cs
+++ b/OpenSynchronos/Services/CharaData/CharaDataFileHandler.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Objects.SubKinds;
 using K4os.Compression.LZ4.Legacy;
 using Microsoft.Extensions.Logging;
 using OpenSynchronos.API.Data;
@@ -141,7 +141,7 @@ public sealed class CharaDataFileHandler : IDisposable
             using var reader = new BinaryReader(lz4Stream);
             var loadedCharaFile = MareCharaFileHeader.FromBinaryReader(filePath, reader);
 
-            _logger.LogInformation("Read Mare Chara File");
+            _logger.LogInformation("Read Character Data File");
             _logger.LogInformation("Version: {ver}", (loadedCharaFile?.Version ?? -1));
             long expectedLength = 0;
             if (loadedCharaFile != null)
@@ -291,7 +291,7 @@ public sealed class CharaDataFileHandler : IDisposable
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failure Saving Mare Chara File, deleting output");
+            _logger.LogError(ex, "Failure Saving Character Data File, deleting output");
             File.Delete(tempFilePath);
         }
     }
@@ -301,3 +301,4 @@ public sealed class CharaDataFileHandler : IDisposable
         return await _fileUploadManager.UploadFiles(fileList, uploadProgress, token).ConfigureAwait(false);
     }
 }
+

--- a/OpenSynchronos/Services/CharaData/Models/MareCharaFileHeader.cs
+++ b/OpenSynchronos/Services/CharaData/Models/MareCharaFileHeader.cs
@@ -1,4 +1,4 @@
-﻿namespace OpenSynchronos.Services.CharaData.Models;
+namespace OpenSynchronos.Services.CharaData.Models;
 
 public record MareCharaFileHeader(byte Version, MareCharaFileData CharaFileData)
 {
@@ -23,7 +23,7 @@ public record MareCharaFileHeader(byte Version, MareCharaFileData CharaFileData)
     public static MareCharaFileHeader? FromBinaryReader(string path, BinaryReader reader)
     {
         var chars = new string(reader.ReadChars(4));
-        if (!string.Equals(chars, "MCDF", StringComparison.Ordinal)) throw new InvalidDataException("Not a Mare Chara File");
+        if (!string.Equals(chars, "MCDF", StringComparison.Ordinal)) throw new InvalidDataException("Not a Character Data File");
 
         MareCharaFileHeader? decoded = null;
 

--- a/OpenSynchronos/Services/CommandManagerService.cs
+++ b/OpenSynchronos/Services/CommandManagerService.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Game.Command;
+using Dalamud.Game.Command;
 using Dalamud.Plugin.Services;
 using OpenSynchronos.FileCache;
 using OpenSynchronos.MareConfiguration;
@@ -38,7 +38,7 @@ public sealed class CommandManagerService : IDisposable
         {
             HelpMessage = "Opens the OpenSynchronos UI" + Environment.NewLine + Environment.NewLine +
                 "Additionally possible commands:" + Environment.NewLine +
-                "\t /os toggle - Disconnects from Mare, if connected. Connects to Mare, if disconnected" + Environment.NewLine +
+                "\t /os toggle - Disconnects from OpenSynchronos, if connected. Connects to OpenSynchronos, if disconnected" + Environment.NewLine +
                 "\t /os toggle on|off - Connects or disconnects to OpenSynchronos respectively" + Environment.NewLine +
                 "\t /os gpose - Opens the OpenSynchronos Character Data Hub window" + Environment.NewLine +
                 "\t /os analyze - Opens the OpenSynchronos Character Data Analysis window" + Environment.NewLine +

--- a/OpenSynchronos/Services/ServerConfiguration/ServerConfigurationManager.cs
+++ b/OpenSynchronos/Services/ServerConfiguration/ServerConfigurationManager.cs
@@ -513,7 +513,7 @@ public class ServerConfigurationManager
         try
         {
             var baseUri = serverUri.Replace("wss://", "https://").Replace("ws://", "http://");
-            var oauthCheckUri = MareAuth.GetUIDsFullPath(new Uri(baseUri));
+            var oauthCheckUri = OpenSynchronosAuth.GetUIDsFullPath(new Uri(baseUri));
             _httpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
             var response = await _httpClient.GetAsync(oauthCheckUri).ConfigureAwait(false);
             var responseStream = await response.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -531,7 +531,7 @@ public class ServerConfigurationManager
         try
         {
             var baseUri = serverUri.Replace("wss://", "https://").Replace("ws://", "http://");
-            var oauthCheckUri = MareAuth.GetDiscordOAuthEndpointFullPath(new Uri(baseUri));
+            var oauthCheckUri = OpenSynchronosAuth.GetDiscordOAuthEndpointFullPath(new Uri(baseUri));
             var response = await _httpClient.GetFromJsonAsync<Uri?>(oauthCheckUri).ConfigureAwait(false);
             _logger.LogInformation("response: {response}", response?.ToString() ?? "null");
             return response;
@@ -557,7 +557,7 @@ public class ServerConfigurationManager
         try
         {
             var baseUri = serverUri.Replace("wss://", "https://").Replace("ws://", "http://");
-            var oauthCheckUri = MareAuth.GetDiscordOAuthTokenFullPath(new Uri(baseUri), sessionId);
+            var oauthCheckUri = OpenSynchronosAuth.GetDiscordOAuthTokenFullPath(new Uri(baseUri), sessionId);
             var response = await _httpClient.GetAsync(oauthCheckUri, linkedCts.Token).ConfigureAwait(false);
             discordToken = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
         }

--- a/OpenSynchronos/UI/CharaDataHubUi.McdOnline.cs
+++ b/OpenSynchronos/UI/CharaDataHubUi.McdOnline.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Utility;
@@ -560,10 +560,10 @@ internal sealed partial class CharaDataHubUi
 
     private void DrawMcdOnline()
     {
-        _uiSharedService.BigText("Mare Character Data Online");
+        _uiSharedService.BigText("OpenSynchronos Character Data Online");
 
-        DrawHelpFoldout("In this tab you can create, view and edit your own Mare Character Data that is stored on the server." + Environment.NewLine + Environment.NewLine
-            + "Mare Character Data Online functions similar to the previous MCDF standard for exporting your character, except that you do not have to send a file to the other person but solely a code." + Environment.NewLine + Environment.NewLine
+        DrawHelpFoldout("In this tab you can create, view and edit your own OpenSynchronos Character Data that is stored on the server." + Environment.NewLine + Environment.NewLine
+            + "OpenSynchronos Character Data Online functions similar to the previous MCDF standard for exporting your character, except that you do not have to send a file to the other person but solely a code." + Environment.NewLine + Environment.NewLine
             + "There would be a bit too much to explain here on what you can do here in its entirety, however, all elements in this tab have help texts attached what they are used for. Please review them carefully." + Environment.NewLine + Environment.NewLine
             + "Be mindful that when you share your Character Data with other people there is a chance that, with the help of unsanctioned 3rd party plugins, your appearance could be stolen irreversibly, just like when using MCDF.");
 

--- a/OpenSynchronos/UI/CharaDataHubUi.cs
+++ b/OpenSynchronos/UI/CharaDataHubUi.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.ImGuiFileDialog;
@@ -79,7 +79,7 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
                          UiSharedService uiSharedService, ServerConfigurationManager serverConfigurationManager,
                          DalamudUtilService dalamudUtilService, FileDialogManager fileDialogManager, PairManager pairManager,
                          CharaDataGposeTogetherManager charaDataGposeTogetherManager)
-        : base(logger, mediator, "OpenSynchronos Character Data Hub###MareSynchronosCharaDataUI", performanceCollectorService)
+        : base(logger, mediator, "OpenSynchronos Character Data Hub###OpenSynchronosCharaDataUI", performanceCollectorService)
     {
         SetWindowSizeConstraints();
 
@@ -863,9 +863,9 @@ internal sealed partial class CharaDataHubUi : WindowMediatorSubscriberBase
 
     private void DrawMcdfExport()
     {
-        _uiSharedService.BigText("Mare Character Data File Export");
+        _uiSharedService.BigText("Character Data File Export");
 
-        DrawHelpFoldout("This feature allows you to pack your character into a MCDF file and manually send it to other people. MCDF files can officially only be imported during GPose through Mare. " +
+        DrawHelpFoldout("This feature allows you to pack your character into a MCDF file and manually send it to other people. MCDF files can officially only be imported during GPose through OpenSynchronos. " +
             "Be aware that the possibility exists that people write unofficial custom exporters to extract the containing data.");
 
         ImGuiHelpers.ScaledDummy(5);

--- a/OpenSynchronos/UI/CompactUI.cs
+++ b/OpenSynchronos/UI/CompactUI.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
@@ -59,7 +59,7 @@ public class CompactUi : WindowMediatorSubscriberBase
         ServerConfigurationManager serverManager, MareMediator mediator, FileUploadManager fileTransferManager,
         TagHandler tagHandler, DrawEntityFactory drawEntityFactory, SelectTagForPairUi selectTagForPairUi, SelectPairForTagUi selectPairForTagUi,
         PerformanceCollectorService performanceCollectorService, IpcManager ipcManager)
-        : base(logger, mediator, "###MareSynchronosMainUI", performanceCollectorService)
+        : base(logger, mediator, "###OpenSynchronosMainUI", performanceCollectorService)
     {
         _uiSharedService = uiShared;
         _configService = configService;
@@ -115,11 +115,11 @@ public class CompactUi : WindowMediatorSubscriberBase
 #if DEBUG
         string dev = "Dev Build";
         var ver = Assembly.GetExecutingAssembly().GetName().Version!;
-        WindowName = $"Mare Synchronos {dev} ({ver.Major}.{ver.Minor}.{ver.Build})###MareSynchronosMainUI";
+        WindowName = $"OpenSynchronos {dev} ({ver.Major}.{ver.Minor}.{ver.Build})###OpenSynchronosMainUI";
         Toggle();
 #else
         var ver = Assembly.GetExecutingAssembly().GetName().Version;
-        WindowName = "Mare Synchronos " + ver.Major + "." + ver.Minor + "." + ver.Build + "###MareSynchronosMainUI";
+        WindowName = "OpenSynchronos " + ver.Major + "." + ver.Minor + "." + ver.Build + "###OpenSynchronosMainUI";
 #endif
         Mediator.Subscribe<SwitchToMainUiMessage>(this, (_) => IsOpen = true);
         Mediator.Subscribe<SwitchToIntroUiMessage>(this, (_) => IsOpen = false);
@@ -152,8 +152,8 @@ public class CompactUi : WindowMediatorSubscriberBase
                 ImGui.AlignTextToFramePadding();
                 ImGui.TextColored(ImGuiColors.DalamudRed, unsupported);
             }
-            UiSharedService.ColorTextWrapped($"Your Mare Synchronos installation is out of date, the current version is {ver.Major}.{ver.Minor}.{ver.Build}. " +
-                $"It is highly recommended to keep Mare Synchronos up to date. Open /xlplugins and update the plugin.", ImGuiColors.DalamudRed);
+            UiSharedService.ColorTextWrapped($"Your OpenSynchronos installation is out of date, the current version is {ver.Major}.{ver.Minor}.{ver.Build}. " +
+                $"It is highly recommended to keep OpenSynchronos up to date. Open /xlplugins and update the plugin.", ImGuiColors.DalamudRed);
         }
 
         if (!_ipcManager.Initialized)
@@ -170,7 +170,7 @@ public class CompactUi : WindowMediatorSubscriberBase
             var penumAvailable = _ipcManager.Penumbra.APIAvailable;
             var glamAvailable = _ipcManager.Glamourer.APIAvailable;
 
-            UiSharedService.ColorTextWrapped($"One or more Plugins essential for Mare operation are unavailable. Enable or update following plugins:", ImGuiColors.DalamudRed);
+            UiSharedService.ColorTextWrapped($"One or more Plugins essential for OpenSynchronos operation are unavailable. Enable or update following plugins:", ImGuiColors.DalamudRed);
             using var indent = ImRaii.PushIndent(10f);
             if (!penumAvailable)
             {
@@ -567,10 +567,10 @@ public class CompactUi : WindowMediatorSubscriberBase
         {
             ServerState.Connecting => "Attempting to connect to the server.",
             ServerState.Reconnecting => "Connection to server interrupted, attempting to reconnect to the server.",
-            ServerState.Disconnected => "You are currently disconnected from the Mare Synchronos server.",
+            ServerState.Disconnected => "You are currently disconnected from the OpenSynchronos server.",
             ServerState.Disconnecting => "Disconnecting from the server",
             ServerState.Unauthorized => "Server Response: " + _apiController.AuthFailureMessage,
-            ServerState.Offline => "Your selected Mare Synchronos server is currently offline.",
+            ServerState.Offline => "Your selected OpenSynchronos server is currently offline.",
             ServerState.VersionMisMatch =>
                 "Your plugin or the server you are connecting to is out of date. Please update your plugin now. If you already did so, contact the server provider to update their server to the latest version.",
             ServerState.RateLimited => "You are rate limited for (re)connecting too often. Disconnect, wait 10 minutes and try again.",
@@ -579,7 +579,7 @@ public class CompactUi : WindowMediatorSubscriberBase
             ServerState.MultiChara => "Your Character Configuration has multiple characters configured with same name and world. You will not be able to connect until you fix this issue. Remove the duplicates from the configuration in Settings -> Service Settings -> Character Management and reconnect manually after.",
             ServerState.OAuthMisconfigured => "OAuth2 is enabled but not fully configured, verify in the Settings -> Service Settings that you have OAuth2 connected and, importantly, a UID assigned to your current character.",
             ServerState.OAuthLoginTokenStale => "Your OAuth2 login token is stale and cannot be used to renew. Go to the Settings -> Service Settings and unlink then relink your OAuth2 configuration.",
-            ServerState.NoAutoLogon => "This character has automatic login into Mare disabled. Press the connect button to connect to Mare.",
+            ServerState.NoAutoLogon => "This character has automatic login into OpenSynchronos disabled. Press the connect button to connect to OpenSynchronos.",
             _ => string.Empty
         };
     }
@@ -639,3 +639,4 @@ public class CompactUi : WindowMediatorSubscriberBase
         IsOpen = false;
     }
 }
+

--- a/OpenSynchronos/UI/Components/Popup/CensusPopupHandler.cs
+++ b/OpenSynchronos/UI/Components/Popup/CensusPopupHandler.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 using OpenSynchronos.Services.ServerConfiguration;
 using System.Numerics;
@@ -41,7 +41,7 @@ public class CensusPopupHandler : IPopupHandler
             + "- Current Race (reflecting Glamourer changes)" + Environment.NewLine
             + "- Current Clan (i.e. Seeker of the Sun, Keeper of the Moon, etc., reflecting Glamourer changes)");
         UiSharedService.TextWrapped("To consent to collecting census data press the appropriate button below.");
-        UiSharedService.TextWrapped("This setting can be changed anytime in the Mare Settings.");
+        UiSharedService.TextWrapped("This setting can be changed anytime in the OpenSynchronos Settings.");
         var width = ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X;
         var buttonSize = ImGuiHelpers.GetButtonSize("I consent to send my census data");
         ImGuiHelpers.ScaledDummy(5f);
@@ -62,3 +62,4 @@ public class CensusPopupHandler : IPopupHandler
         _size = _size with { Y = height };
     }
 }
+

--- a/OpenSynchronos/UI/CreateSyncshellUI.cs
+++ b/OpenSynchronos/UI/CreateSyncshellUI.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Utility;
 using OpenSynchronos.API.Data.Extensions;
@@ -20,7 +20,7 @@ public class CreateSyncshellUI : WindowMediatorSubscriberBase
 
     public CreateSyncshellUI(ILogger<CreateSyncshellUI> logger, MareMediator mareMediator, ApiController apiController, UiSharedService uiSharedService,
         PerformanceCollectorService performanceCollectorService)
-        : base(logger, mareMediator, "Create new Syncshell###MareSynchronosCreateSyncshell", performanceCollectorService)
+        : base(logger, mareMediator, "Create new Syncshell###OpenSynchronosCreateSyncshell", performanceCollectorService)
     {
         _apiController = apiController;
         _uiSharedService = uiSharedService;

--- a/OpenSynchronos/UI/DataAnalysisUi.cs
+++ b/OpenSynchronos/UI/DataAnalysisUi.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
@@ -167,9 +167,9 @@ public class DataAnalysisUi : WindowMediatorSubscriberBase
         {
             UiSharedService.TextWrapped("This tab allows you to see which transient files are attached to your character.");
             UiSharedService.TextWrapped("Transient files are files that cannot be resolved to your character permanently. OpenSynchronos gathers these files in the background while you execute animations, VFX, sound effects, etc.");
-            UiSharedService.TextWrapped("When sending your character data to others, Mare will combine the files listed in \"All Jobs\" and the corresponding currently used job.");
+            UiSharedService.TextWrapped("When sending your character data to others, OpenSynchronos will combine the files listed in \"All Jobs\" and the corresponding currently used job.");
             UiSharedService.TextWrapped("The purpose of this tab is primarily informational for you to see which files you are carrying with you. You can remove added game paths, however if you are using the animations etc. again, "
-                + "Mare will automatically attach these after using them. If you disable associated mods in Penumbra, the associated entries here will also be deleted automatically.");
+                + "OpenSynchronos will automatically attach these after using them. If you disable associated mods in Penumbra, the associated entries here will also be deleted automatically.");
         });
 
         ImGuiHelpers.ScaledDummy(5);
@@ -292,7 +292,7 @@ public class DataAnalysisUi : WindowMediatorSubscriberBase
                     }
                 }
                 UiSharedService.AttachToolTip("Hold CTRL to delete all game paths from the displayed list"
-                    + UiSharedService.TooltipSeparator + "You usually do not need to do this. All animation and VFX data will be automatically handled through Mare.");
+                    + UiSharedService.TooltipSeparator + "You usually do not need to do this. All animation and VFX data will be automatically handled through OpenSynchronos.");
                 ImGuiHelpers.ScaledDummy(5);
                 ImGuiHelpers.ScaledDummy(30);
                 ImGui.SameLine();
@@ -366,7 +366,7 @@ public class DataAnalysisUi : WindowMediatorSubscriberBase
         {
             UiSharedService.TextWrapped("This tab allows you to attempt to fix mods that do not sync correctly, especially those with modded models and animations." + Environment.NewLine + Environment.NewLine
                 + "To use this, start the recording, execute one or multiple emotes/animations you want to attempt to fix and check if new data appears in the table below." + Environment.NewLine
-                + "If it doesn't, Mare is not able to catch the data or already has recorded the animation files (check 'Show previously added transient files' to see if not all is already present)." + Environment.NewLine + Environment.NewLine
+                + "If it doesn't, OpenSynchronos is not able to catch the data or already has recorded the animation files (check 'Show previously added transient files' to see if not all is already present)." + Environment.NewLine + Environment.NewLine
                 + "For most animations, vfx, etc. it is enough to just run them once unless they have random variations. Longer animations do not require to play out in their entirety to be captured.");
             ImGuiHelpers.ScaledDummy(5);
             UiSharedService.DrawGroupedCenteredColorText("Important Note: If you need to fix an animation that should apply across multiple jobs, you need to repeat this process with at least one additional job, " +
@@ -406,7 +406,7 @@ public class DataAnalysisUi : WindowMediatorSubscriberBase
 
         ImGuiHelpers.ScaledDummy(5);
         ImGui.Checkbox("Show previously added transient files in the recording", ref _showAlreadyAddedTransients);
-        _uiSharedService.DrawHelpText("Use this only if you want to see what was previously already caught by Mare");
+        _uiSharedService.DrawHelpText("Use this only if you want to see what was previously already caught by OpenSynchronos");
         ImGuiHelpers.ScaledDummy(5);
 
         using (ImRaii.Disabled(_transientResourceManager.IsTransientRecording || _transientResourceManager.RecordedTransients.All(k => !k.AddTransient) || !_acknowledgeReview))
@@ -476,7 +476,7 @@ public class DataAnalysisUi : WindowMediatorSubscriberBase
     {
         UiSharedService.DrawTree("What is this? (Explanation / Help)", () =>
         {
-            UiSharedService.TextWrapped("This tab shows you all files and their sizes that are currently in use through your character and associated entities in Mare");
+            UiSharedService.TextWrapped("This tab shows you all files and their sizes that are currently in use through your character and associated entities in OpenSynchronos");
         });
 
         if (_cachedAnalysis!.Count == 0) return;
@@ -877,3 +877,4 @@ public class DataAnalysisUi : WindowMediatorSubscriberBase
         }
     }
 }
+

--- a/OpenSynchronos/UI/EditProfileUi.cs
+++ b/OpenSynchronos/UI/EditProfileUi.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.ImGuiFileDialog;
@@ -33,7 +33,7 @@ public class EditProfileUi : WindowMediatorSubscriberBase
     public EditProfileUi(ILogger<EditProfileUi> logger, MareMediator mediator,
         ApiController apiController, UiSharedService uiSharedService, FileDialogManager fileDialogManager,
         MareProfileManager mareProfileManager, PerformanceCollectorService performanceCollectorService)
-        : base(logger, mediator, "OpenSynchronos Edit Profile###MareSynchronosEditProfileUI", performanceCollectorService)
+        : base(logger, mediator, "OpenSynchronos Edit Profile###OpenSynchronosEditProfileUI", performanceCollectorService)
     {
         IsOpen = false;
         this.SizeConstraints = new()
@@ -126,7 +126,7 @@ public class EditProfileUi : WindowMediatorSubscriberBase
             $"- Other users have the possibility to report your profile for breaking the rules.{Environment.NewLine}" +
             $"- !!! AVOID: anything as profile image that can be considered highly illegal or obscene (bestiality, anything that could be considered a sexual act with a minor (that includes Lalafells), etc.){Environment.NewLine}" +
             $"- !!! AVOID: slurs of any kind in the description that can be considered highly offensive{Environment.NewLine}" +
-            $"- In case of valid reports from other users this can lead to disabling your profile forever or terminating your Mare account indefinitely.{Environment.NewLine}" +
+            $"- In case of valid reports from other users this can lead to disabling your profile forever or terminating your OpenSynchronos account indefinitely.{Environment.NewLine}" +
             $"- Judgement of your profile validity from reports through staff is not up to debate and the decisions to disable your profile/account permanent.{Environment.NewLine}" +
             $"- If your profile picture or profile description could be considered NSFW, enable the toggle below.");
         ImGui.Separator();

--- a/OpenSynchronos/UI/IntroUI.cs
+++ b/OpenSynchronos/UI/IntroUI.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
@@ -21,7 +21,7 @@ public partial class IntroUi : WindowMediatorSubscriberBase
 {
     private readonly MareConfigService _configService;
     private readonly CacheMonitor _cacheMonitor;
-    private readonly Dictionary<string, string> _languages = new(StringComparer.Ordinal) { { "English", "en" }, { "Deutsch", "de" }, { "Français", "fr" } };
+    private readonly Dictionary<string, string> _languages = new(StringComparer.Ordinal) { { "English", "en" }, { "Deutsch", "de" }, { "Francais", "fr" } };
     private readonly ServerConfigurationManager _serverConfigurationManager;
     private readonly DalamudUtilService _dalamudUtilService;
     private readonly UiSharedService _uiShared;
@@ -73,7 +73,7 @@ public partial class IntroUi : WindowMediatorSubscriberBase
         {
             _uiShared.BigText("Welcome to OpenSynchronos");
             ImGui.Separator();
-            UiSharedService.TextWrapped("OpenSynchronos is a plugin that will replicate your full current character state including all Penumbra mods to other paired Mare Synchronos users. " +
+            UiSharedService.TextWrapped("OpenSynchronos is a plugin that will replicate your full current character state including all Penumbra mods to other paired OpenSynchronos users. " +
                               "Note that you will have to have Penumbra as well as Glamourer installed to use this plugin.");
             UiSharedService.TextWrapped("We will have to setup a few things first before you can start using this plugin. Click on next to continue.");
 
@@ -168,11 +168,11 @@ public partial class IntroUi : WindowMediatorSubscriberBase
             }
             else
             {
-                UiSharedService.TextWrapped("To not unnecessary download files already present on your computer, Mare Synchronos will have to scan your Penumbra mod directory. " +
+                UiSharedService.TextWrapped("To not unnecessary download files already present on your computer, OpenSynchronos will have to scan your Penumbra mod directory. " +
                                      "Additionally, a local storage folder must be set where Synchronos will download other character files to. " +
                                      "Once the storage folder is set and the scan complete, this page will automatically forward to registration at a service.");
                 UiSharedService.TextWrapped("Note: The initial scan, depending on the amount of mods you have, might take a while. Please wait until it is completed.");
-                UiSharedService.ColorTextWrapped("Warning: once past this step you should not delete the FileCache.csv of Mare Synchronos in the Plugin Configurations folder of Dalamud. " +
+                UiSharedService.ColorTextWrapped("Warning: once past this step you should not delete the FileCache.csv of OpenSynchronos in the Plugin Configurations folder of Dalamud. " +
                                           "Otherwise on the next launch a full re-scan of the file cache database will be initiated.", ImGuiColors.DalamudYellow);
                 UiSharedService.ColorTextWrapped("Warning: if the scan is hanging and does nothing for a long time, chances are high your Penumbra folder is not set up properly.", ImGuiColors.DalamudYellow);
                 _uiShared.DrawCacheDirectorySetting();
@@ -197,8 +197,8 @@ public partial class IntroUi : WindowMediatorSubscriberBase
                     _configService.Current.UseCompactor = useFileCompactor;
                     _configService.Save();
                 }
-                UiSharedService.ColorTextWrapped("The File Compactor can save a tremendeous amount of space on the hard disk for downloads through Mare. It will incur a minor CPU penalty on download but can speed up " +
-                    "loading of other characters. It is recommended to keep it enabled. You can change this setting later anytime in the Mare settings.", ImGuiColors.DalamudYellow);
+                UiSharedService.ColorTextWrapped("The File Compactor can save a tremendeous amount of space on the hard disk for downloads through OpenSynchronos. It will incur a minor CPU penalty on download but can speed up " +
+                    "loading of other characters. It is recommended to keep it enabled. You can change this setting later anytime in the OpenSynchronos settings.", ImGuiColors.DalamudYellow);
             }
         }
         else if (!_uiShared.ApiController.ServerAlive)
@@ -349,3 +349,4 @@ public partial class IntroUi : WindowMediatorSubscriberBase
     [GeneratedRegex("^([A-F0-9]{2})+")]
     private static partial Regex HexRegex();
 }
+

--- a/OpenSynchronos/UI/JoinSyncshellUI.cs
+++ b/OpenSynchronos/UI/JoinSyncshellUI.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
@@ -26,7 +26,7 @@ internal class JoinSyncshellUI : WindowMediatorSubscriberBase
 
     public JoinSyncshellUI(ILogger<JoinSyncshellUI> logger, MareMediator mediator,
         UiSharedService uiSharedService, ApiController apiController, PerformanceCollectorService performanceCollectorService) 
-        : base(logger, mediator, "Join existing Syncshell###MareSynchronosJoinSyncshell", performanceCollectorService)
+        : base(logger, mediator, "Join existing Syncshell###OpenSynchronosJoinSyncshell", performanceCollectorService)
     {
         _uiSharedService = uiSharedService;
         _apiController = apiController;

--- a/OpenSynchronos/UI/PermissionWindowUI.cs
+++ b/OpenSynchronos/UI/PermissionWindowUI.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using OpenSynchronos.API.Data.Extensions;
@@ -22,7 +22,7 @@ public class PermissionWindowUI : WindowMediatorSubscriberBase
 
     public PermissionWindowUI(ILogger<PermissionWindowUI> logger, Pair pair, MareMediator mediator, UiSharedService uiSharedService,
         ApiController apiController, PerformanceCollectorService performanceCollectorService)
-        : base(logger, mediator, "Permissions for " + pair.UserData.AliasOrUID + "###MareSynchronosPermissions" + pair.UserData.UID, performanceCollectorService)
+        : base(logger, mediator, "Permissions for " + pair.UserData.AliasOrUID + "###OpenSynchronosPermissions" + pair.UserData.UID, performanceCollectorService)
     {
         Pair = pair;
         _uiSharedService = uiSharedService;
@@ -175,7 +175,7 @@ public class PermissionWindowUI : WindowMediatorSubscriberBase
                 new(StringComparer.Ordinal)
             ));
         }
-        UiSharedService.AttachToolTip("This will set all permissions to your defined default permissions in the Mare Settings");
+        UiSharedService.AttachToolTip("This will set all permissions to your defined default permissions in the OpenSynchronos Settings");
 
         var ySize = ImGui.GetCursorPosY() + style.FramePadding.Y * ImGuiHelpers.GlobalScale + style.FrameBorderSize;
         ImGui.SetWindowSize(new(400, ySize));
@@ -186,3 +186,4 @@ public class PermissionWindowUI : WindowMediatorSubscriberBase
         Mediator.Publish(new RemoveWindowMessage(this));
     }
 }
+

--- a/OpenSynchronos/UI/PopoutProfileUi.cs
+++ b/OpenSynchronos/UI/PopoutProfileUi.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Interface.Utility;
@@ -29,7 +29,7 @@ public class PopoutProfileUi : WindowMediatorSubscriberBase
 
     public PopoutProfileUi(ILogger<PopoutProfileUi> logger, MareMediator mediator, UiSharedService uiBuilder,
         ServerConfigurationManager serverManager, MareConfigService mareConfigService,
-        MareProfileManager mareProfileManager, PairManager pairManager, PerformanceCollectorService performanceCollectorService) : base(logger, mediator, "###MareSynchronosPopoutProfileUI", performanceCollectorService)
+        MareProfileManager mareProfileManager, PairManager pairManager, PerformanceCollectorService performanceCollectorService) : base(logger, mediator, "###OpenSynchronosPopoutProfileUI", performanceCollectorService)
     {
         _uiSharedService = uiBuilder;
         _serverManager = serverManager;

--- a/OpenSynchronos/UI/SettingsUi.cs
+++ b/OpenSynchronos/UI/SettingsUi.cs
@@ -179,7 +179,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         _lastTab = "BlockedTransfers";
         UiSharedService.ColorTextWrapped("Files that you attempted to upload or download that were forbidden to be transferred by their creators will appear here. " +
                              "If you see file paths from your drive here, then those files were not allowed to be uploaded. If you see hashes, those files were not allowed to be downloaded. " +
-                             "Ask your paired friend to send you the mod in question through other means, acquire the mod yourself or pester the mod creator to allow it to be sent over Mare.",
+                             "Ask your paired friend to send you the mod in question through other means, acquire the mod yourself or ask the mod creator to allow it to be sent over OpenSynchronos.",
             ImGuiColors.DalamudGrey);
 
         if (ImGui.BeginTable("TransfersTable", 2, ImGuiTableFlags.SizingStretchProp))
@@ -635,7 +635,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         _uiShared.IconText(FontAwesomeIcon.UserCog);
         ImGui.SameLine();
         UiSharedService.TextWrapped(") -> \"Character Data Hub\".");
-        if (_uiShared.IconTextButton(FontAwesomeIcon.Running, "Open Mare Character Data Hub"))
+        if (_uiShared.IconTextButton(FontAwesomeIcon.Running, "Open OpenSynchronos Character Data Hub"))
         {
             Mediator.Publish(new UiToggleMessage(typeof(CharaDataHubUi)));
         }
@@ -645,7 +645,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
 
         _uiShared.BigText("Storage");
 
-        UiSharedService.TextWrapped("Mare stores downloaded files from paired people permanently. This is to improve loading performance and requiring less downloads. " +
+        UiSharedService.TextWrapped("OpenSynchronos stores downloaded files from paired people permanently. This is to improve loading performance and requiring less downloads. " +
             "The storage governs itself by clearing data beyond the set storage size. Please set the storage size accordingly. It is not necessary to manually clear the storage.");
 
         _uiShared.DrawFileScanState();
@@ -662,7 +662,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         }
 
         ImGui.AlignTextToFramePadding();
-        ImGui.TextUnformatted("Monitoring Mare Storage Folder: " + (_cacheMonitor.MareWatcher?.Path ?? "Not monitoring"));
+        ImGui.TextUnformatted("Monitoring OpenSynchronos Storage Folder: " + (_cacheMonitor.MareWatcher?.Path ?? "Not monitoring"));
         if (string.IsNullOrEmpty(_cacheMonitor.MareWatcher?.Path))
         {
             ImGui.SameLine();
@@ -680,7 +680,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
                 _cacheMonitor.StartPenumbraWatcher(_ipcManager.Penumbra.ModDirectory);
                 _cacheMonitor.InvokeScan();
             }
-            UiSharedService.AttachToolTip("Attempts to resume monitoring for both Penumbra and Mare Storage. "
+            UiSharedService.AttachToolTip("Attempts to resume monitoring for both Penumbra and OpenSynchronos Storage. "
                 + "Resuming the monitoring will also force a full scan to run." + Environment.NewLine
                 + "If the button remains present after clicking it, consult /xllog for errors");
         }
@@ -693,8 +693,8 @@ public class SettingsUi : WindowMediatorSubscriberBase
                     _cacheMonitor.StopMonitoring();
                 }
             }
-            UiSharedService.AttachToolTip("Stops the monitoring for both Penumbra and Mare Storage. "
-                + "Do not stop the monitoring, unless you plan to move the Penumbra and Mare Storage folders, to ensure correct functionality of Mare." + Environment.NewLine
+            UiSharedService.AttachToolTip("Stops the monitoring for both Penumbra and OpenSynchronos Storage. "
+                + "Do not stop the monitoring, unless you plan to move the Penumbra and OpenSynchronos Storage folders, to ensure correct functionality of OpenSynchronos." + Environment.NewLine
                 + "If you stop the monitoring to move folders around, resume it after you are finished moving the files."
                 + UiSharedService.TooltipSeparator + "Hold CTRL to enable this button");
         }
@@ -710,7 +710,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         bool isLinux = _dalamudUtilService.IsWine;
         if (!useFileCompactor && !isLinux)
         {
-            UiSharedService.ColorTextWrapped("Hint: To free up space when using Mare consider enabling the File Compactor", ImGuiColors.DalamudYellow);
+            UiSharedService.ColorTextWrapped("Hint: To free up space when using OpenSynchronos consider enabling the File Compactor", ImGuiColors.DalamudYellow);
         }
         if (isLinux || !_cacheMonitor.StorageisNTFS) ImGui.BeginDisabled();
         if (ImGui.Checkbox("Use file compactor", ref useFileCompactor))
@@ -731,7 +731,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
                     _cacheMonitor.RecalculateFileCacheSize(CancellationToken.None);
                 });
             }
-            UiSharedService.AttachToolTip("This will run compression on all files in your current Mare Storage." + Environment.NewLine
+            UiSharedService.AttachToolTip("This will run compression on all files in your current OpenSynchronos Storage." + Environment.NewLine
                 + "You do not need to run this manually if you keep the file compactor enabled.");
             ImGui.SameLine();
             if (_uiShared.IconTextButton(FontAwesomeIcon.File, "Decompact all files in storage"))
@@ -742,7 +742,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
                     _cacheMonitor.RecalculateFileCacheSize(CancellationToken.None);
                 });
             }
-            UiSharedService.AttachToolTip("This will run decompression on all files in your current Mare Storage.");
+            UiSharedService.AttachToolTip("This will run decompression on all files in your current OpenSynchronos Storage.");
         }
         else
         {
@@ -756,7 +756,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         ImGuiHelpers.ScaledDummy(new Vector2(10, 10));
 
         ImGui.Separator();
-        UiSharedService.TextWrapped("File Storage validation can make sure that all files in your local Mare Storage are valid. " +
+        UiSharedService.TextWrapped("File Storage validation can make sure that all files in your local OpenSynchronos Storage are valid. " +
             "Run the validation before you clear the Storage for no reason. " + Environment.NewLine +
             "This operation, depending on how many files you have in your storage, can take a while and will be CPU and drive intensive.");
         using (ImRaii.Disabled(_validationTask != null && !_validationTask.IsCompleted))
@@ -906,14 +906,14 @@ public class SettingsUi : WindowMediatorSubscriberBase
             _configService.Current.EnableRightClickMenus = enableRightClickMenu;
             _configService.Save();
         }
-        _uiShared.DrawHelpText("This will add Mare related right click menu entries in the game UI on paired players.");
+        _uiShared.DrawHelpText("This will add OpenSynchronos related right click menu entries in the game UI on paired players.");
 
         if (ImGui.Checkbox("Display status and visible pair count in Server Info Bar", ref enableDtrEntry))
         {
             _configService.Current.EnableDtrEntry = enableDtrEntry;
             _configService.Save();
         }
-        _uiShared.DrawHelpText("This will add Mare connection status and visible pair count in the Server Info Bar.\nYou can further configure this through your Dalamud Settings.");
+        _uiShared.DrawHelpText("This will add OpenSynchronos connection status and visible pair count in the Server Info Bar.\nYou can further configure this through your Dalamud Settings.");
 
         using (ImRaii.Disabled(!enableDtrEntry))
         {
@@ -1033,7 +1033,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
             _configService.Save();
         }
 
-        if (ImGui.Checkbox("Show Mare Profiles on Hover", ref showProfiles))
+        if (ImGui.Checkbox("Show OpenSynchronos Profiles on Hover", ref showProfiles))
         {
             Mediator.Publish(new ClearProfileDataMessage());
             _configService.Current.ProfilesShow = showProfiles;
@@ -1157,7 +1157,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
             _playerPerformanceConfigService.Current.WarnOnExceedingThresholds = warnOnExceedingThresholds;
             _playerPerformanceConfigService.Save();
         }
-        _uiShared.DrawHelpText("Mare will print a warning in chat once per session of meeting those people. Will not warn on players with preferred permissions.");
+        _uiShared.DrawHelpText("OpenSynchronos will print a warning in chat once per session of meeting those people. Will not warn on players with preferred permissions.");
         using (ImRaii.Disabled(!warnOnExceedingThresholds && !showPerformanceIndicator))
         {
             using var indent = ImRaii.PushIndent();
@@ -1167,7 +1167,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
                 _playerPerformanceConfigService.Current.WarnOnPreferredPermissionsExceedingThresholds = warnOnPref;
                 _playerPerformanceConfigService.Save();
             }
-            _uiShared.DrawHelpText("Mare will also print warnings and show performance indicator for players where you enabled preferred permissions. If warning in general is disabled, this will not produce any warnings.");
+            _uiShared.DrawHelpText("OpenSynchronos will also print warnings and show performance indicator for players where you enabled preferred permissions. If warning in general is disabled, this will not produce any warnings.");
         }
         using (ImRaii.Disabled(!showPerformanceIndicator && !warnOnExceedingThresholds))
         {
@@ -1410,7 +1410,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
             {
                 if (selectedServer.SecretKeys.Any() || useOauth)
                 {
-                    UiSharedService.ColorTextWrapped("Characters listed here will automatically connect to the selected Mare service with the settings as provided below." +
+                    UiSharedService.ColorTextWrapped("Characters listed here will automatically connect to the selected OpenSynchronos service with the settings as provided below." +
                         " Make sure to enter the character names correctly or use the 'Add current character' button at the bottom.", ImGuiColors.DalamudYellow);
                     int i = 0;
                     _uiShared.DrawUpdateOAuthUIDsButton(selectedServer);
@@ -1583,12 +1583,12 @@ public class SettingsUi : WindowMediatorSubscriberBase
                             _uiShared.DrawUIDComboForAuthentication(i, item, selectedServer.ServerUri, _logger);
                         }
                         bool isAutoLogin = item.AutoLogin;
-                        if (ImGui.Checkbox("Automatically login to Mare", ref isAutoLogin))
+                        if (ImGui.Checkbox("Automatically login to OpenSynchronos", ref isAutoLogin))
                         {
                             item.AutoLogin = isAutoLogin;
                             _serverConfigurationManager.Save();
                         }
-                        _uiShared.DrawHelpText("When enabled and logging into this character in XIV, Mare will automatically connect to the current service.");
+                        _uiShared.DrawHelpText("When enabled and logging into this character in XIV, OpenSynchronos will automatically connect to the current service.");
                         if (_uiShared.IconTextButton(FontAwesomeIcon.Trash, "Delete Character") && UiSharedService.CtrlPressed())
                             _serverConfigurationManager.RemoveCharacterFromServer(idx, item);
                         UiSharedService.AttachToolTip("Hold CTRL to delete this entry.");
@@ -1720,7 +1720,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
                         selectedServer.ForceWebSockets = forceWebSockets;
                         _serverConfigurationManager.Save();
                     }
-                    _uiShared.DrawHelpText("On wine, Mare will automatically fall back to ServerSentEvents/LongPolling, even if WebSockets is selected. "
+                    _uiShared.DrawHelpText("On wine, OpenSynchronos will automatically fall back to ServerSentEvents/LongPolling, even if WebSockets is selected. "
                         + "WebSockets are known to crash XIV entirely on wine 8.5 shipped with Dalamud. "
                         + "Only enable this if you are not running wine 8.5." + Environment.NewLine
                         + "Note: If the issue gets resolved at some point this option will be removed.");
@@ -1877,7 +1877,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         }
 
         var baseUri = serverStorage.ServerUri.Replace("wss://", "https://").Replace("ws://", "http://");
-        var oauthCheckUri = MareAuth.GetUIDsBasedOnSecretKeyFullPath(new Uri(baseUri));
+        var oauthCheckUri = OpenSynchronosAuth.GetUIDsBasedOnSecretKeyFullPath(new Uri(baseUri));
         var requestContent = JsonContent.Create(secretKeyMapping.Select(k => k.Key).ToList());
         HttpRequestMessage requestMessage = new(HttpMethod.Post, oauthCheckUri);
         requestMessage.Headers.Authorization = new AuthenticationHeaderValue("Bearer", serverStorage.OAuthToken);
@@ -1941,7 +1941,7 @@ public class SettingsUi : WindowMediatorSubscriberBase
         ImGui.AlignTextToFramePadding();
         ImGui.TextUnformatted("Community and Support:");
         ImGui.SameLine();
-        if (ImGui.Button("Mare Synchronos Discord"))
+        if (ImGui.Button("OpenSynchronos Discord"))
         {
             Util.OpenLink("https://discord.gg/mpNdkrTRjW");
         }
@@ -1999,3 +1999,6 @@ public class SettingsUi : WindowMediatorSubscriberBase
         IsOpen = false;
     }
 }
+
+
+

--- a/OpenSynchronos/UI/StandaloneProfileUi.cs
+++ b/OpenSynchronos/UI/StandaloneProfileUi.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Interface.Utility;
@@ -27,7 +27,7 @@ public class StandaloneProfileUi : WindowMediatorSubscriberBase
     public StandaloneProfileUi(ILogger<StandaloneProfileUi> logger, MareMediator mediator, UiSharedService uiBuilder,
         ServerConfigurationManager serverManager, MareProfileManager mareProfileManager, PairManager pairManager, Pair pair,
         PerformanceCollectorService performanceCollector)
-        : base(logger, mediator, "OpenSynchronos Profile of " + pair.UserData.AliasOrUID + "##MareSynchronosStandaloneProfileUI" + pair.UserData.AliasOrUID, performanceCollector)
+        : base(logger, mediator, "OpenSynchronos Profile of " + pair.UserData.AliasOrUID + "##OpenSynchronosStandaloneProfileUI" + pair.UserData.AliasOrUID, performanceCollector)
     {
         _uiSharedService = uiBuilder;
         _serverManager = serverManager;

--- a/OpenSynchronos/UI/SyncshellAdminUI.cs
+++ b/OpenSynchronos/UI/SyncshellAdminUI.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.Utility;
@@ -260,7 +260,7 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
                         _pruneTestTask = _apiController.GroupPrune(new(GroupFullInfo.Group), _pruneDays, execute: false);
                         _pruneTask = null;
                     }
-                    UiSharedService.AttachToolTip($"This will start the prune process for this Syncshell of inactive Mare users that have not logged in in the past {_pruneDays} days."
+                    UiSharedService.AttachToolTip($"This will start the prune process for this Syncshell of inactive OpenSynchronos users that have not logged in in the past {_pruneDays} days."
                         + Environment.NewLine + "You will be able to review the amount of inactive users before executing the prune."
                         + UiSharedService.TooltipSeparator + "Note: this check excludes pinned users and moderators of this Syncshell.");
                     ImGui.SameLine();
@@ -286,7 +286,7 @@ public class SyncshellAdminUI : WindowMediatorSubscriberBase
                         else
                         {
                             ImGui.AlignTextToFramePadding();
-                            UiSharedService.TextWrapped($"Found {_pruneTestTask.Result} user(s) that have not logged into Mare in the past {_pruneDays} days.");
+                            UiSharedService.TextWrapped($"Found {_pruneTestTask.Result} user(s) that have not logged into OpenSynchronos in the past {_pruneDays} days.");
                             if (_pruneTestTask.Result > 0)
                             {
                                 using (ImRaii.Disabled(!UiSharedService.CtrlPressed()))

--- a/OpenSynchronos/UI/UISharedService.cs
+++ b/OpenSynchronos/UI/UISharedService.cs
@@ -1,4 +1,4 @@
-﻿using Dalamud.Bindings.ImGui;
+using Dalamud.Bindings.ImGui;
 using Dalamud.Interface;
 using Dalamud.Interface.Colors;
 using Dalamud.Interface.GameFonts;
@@ -453,7 +453,7 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
 
     public void DrawCacheDirectorySetting()
     {
-        ColorTextWrapped("Note: The storage folder should be somewhere close to root (i.e. C:\\MareStorage) in a new empty folder. DO NOT point this to your game folder. DO NOT point this to your Penumbra folder.", ImGuiColors.DalamudYellow);
+        ColorTextWrapped("Note: The storage folder should be somewhere close to root (i.e. C:\\OpenSynchronosStorage) in a new empty folder. DO NOT point this to your game folder. DO NOT point this to your Penumbra folder.", ImGuiColors.DalamudYellow);
         var cacheDirectory = _configService.Current.CacheFolder;
         ImGui.InputText("Storage Folder##cache", ref cacheDirectory, 255, ImGuiInputTextFlags.ReadOnly);
 
@@ -462,7 +462,7 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
         {
             if (IconButton(FontAwesomeIcon.Folder))
             {
-                FileDialogManager.OpenFolderDialog("Pick Mare Synchronos Storage Folder", (success, path) =>
+                FileDialogManager.OpenFolderDialog("Pick OpenSynchronos Storage Folder", (success, path) =>
                 {
                     if (!success) return;
 
@@ -484,7 +484,7 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
                     if (dirs.Any())
                     {
                         _cacheDirectoryHasOtherFilesThanCache = true;
-                        Logger.LogWarning("Found folders in {path} not belonging to Mare: {dirs}", path, string.Join(", ", dirs));
+                        Logger.LogWarning("Found folders in {path} not belonging to OpenSynchronos: {dirs}", path, string.Join(", ", dirs));
                     }
 
                     _isDirectoryWritable = IsDirectoryWritable(path);
@@ -525,7 +525,7 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
         }
         else if (_cacheDirectoryHasOtherFilesThanCache)
         {
-            ColorTextWrapped("Your selected directory has files or directories inside that are not OpenSynchronos related. Use an empty directory or a previous Mare storage directory only.", ImGuiColors.DalamudRed);
+            ColorTextWrapped("Your selected directory has files or directories inside that are not OpenSynchronos related. Use an empty directory or a previous OpenSynchronos storage directory only.", ImGuiColors.DalamudRed);
         }
         else if (!_cacheDirectoryIsValidPath)
         {
@@ -539,7 +539,7 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
             _configService.Current.MaxLocalCacheInGiB = maxCacheSize;
             _configService.Save();
         }
-        DrawHelpText("The storage is automatically governed by Mare. It will clear itself automatically once it reaches the set capacity by removing the oldest unused files. You typically do not need to clear it yourself.");
+        DrawHelpText("The storage is automatically governed by OpenSynchronos. It will clear itself automatically once it reaches the set capacity by removing the oldest unused files. You typically do not need to clear it yourself.");
     }
 
     public T? DrawCombo<T>(string comboName, IEnumerable<T> comboItems, Func<T?, string> toName,
@@ -1145,3 +1145,4 @@ public partial class UiSharedService : DisposableMediatorSubscriberBase
     public sealed record IconScaleData(Vector2 IconSize, Vector2 NormalizedIconScale, float OffsetX, float IconScaling);
     private record UIDAliasPair(string? UID, string? Alias);
 }
+

--- a/OpenSynchronos/WebAPI/Files/FileDownloadManager.cs
+++ b/OpenSynchronos/WebAPI/Files/FileDownloadManager.cs
@@ -145,7 +145,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
         _downloadStatus[downloadGroup].DownloadStatus = DownloadStatus.Downloading;
 
         HttpResponseMessage response = null!;
-        var requestUrl = MareFiles.CacheGetFullPath(fileTransfer[0].DownloadUri, requestId);
+        var requestUrl = OpenSynchronosFiles.CacheGetFullPath(fileTransfer[0].DownloadUri, requestId);
 
         Logger.LogDebug("Downloading {requestUrl} for request {id}", requestUrl, requestId);
         try
@@ -268,7 +268,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
         async (fileGroup, token) =>
         {
             // let server predownload files
-            var requestIdResponse = await _orchestrator.SendRequestAsync(HttpMethod.Post, MareFiles.RequestEnqueueFullPath(fileGroup.First().DownloadUri),
+            var requestIdResponse = await _orchestrator.SendRequestAsync(HttpMethod.Post, OpenSynchronosFiles.RequestEnqueueFullPath(fileGroup.First().DownloadUri),
                 fileGroup.Select(c => c.Hash), token).ConfigureAwait(false);
             Logger.LogDebug("Sent request for {n} files on server {uri} with result {result}", fileGroup.Count(), fileGroup.First().DownloadUri,
                 await requestIdResponse.Content.ReadAsStringAsync(token).ConfigureAwait(false));
@@ -378,7 +378,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
     private async Task<List<DownloadFileDto>> FilesGetSizes(List<string> hashes, CancellationToken ct)
     {
         if (!_orchestrator.IsInitialized) throw new InvalidOperationException("FileTransferManager is not initialized");
-        var response = await _orchestrator.SendRequestAsync(HttpMethod.Get, MareFiles.ServerFilesGetSizesFullPath(_orchestrator.FilesCdnUri!), hashes, ct).ConfigureAwait(false);
+        var response = await _orchestrator.SendRequestAsync(HttpMethod.Get, OpenSynchronosFiles.ServerFilesGetSizesFullPath(_orchestrator.FilesCdnUri!), hashes, ct).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<List<DownloadFileDto>>(cancellationToken: ct).ConfigureAwait(false) ?? [];
     }
 
@@ -431,7 +431,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
                 {
                     if (downloadCt.IsCancellationRequested) throw;
 
-                    var req = await _orchestrator.SendRequestAsync(HttpMethod.Get, MareFiles.RequestCheckQueueFullPath(downloadFileTransfer[0].DownloadUri, requestId),
+                    var req = await _orchestrator.SendRequestAsync(HttpMethod.Get, OpenSynchronosFiles.RequestCheckQueueFullPath(downloadFileTransfer[0].DownloadUri, requestId),
                         downloadFileTransfer.Select(c => c.Hash).ToList(), downloadCt).ConfigureAwait(false);
                     req.EnsureSuccessStatusCode();
                     localTimeoutCts.Dispose();
@@ -451,7 +451,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
         {
             try
             {
-                await _orchestrator.SendRequestAsync(HttpMethod.Get, MareFiles.RequestCancelFullPath(downloadFileTransfer[0].DownloadUri, requestId)).ConfigureAwait(false);
+                await _orchestrator.SendRequestAsync(HttpMethod.Get, OpenSynchronosFiles.RequestCancelFullPath(downloadFileTransfer[0].DownloadUri, requestId)).ConfigureAwait(false);
                 alreadyCancelled = true;
             }
             catch
@@ -467,7 +467,7 @@ public partial class FileDownloadManager : DisposableMediatorSubscriberBase
             {
                 try
                 {
-                    await _orchestrator.SendRequestAsync(HttpMethod.Get, MareFiles.RequestCancelFullPath(downloadFileTransfer[0].DownloadUri, requestId)).ConfigureAwait(false);
+                    await _orchestrator.SendRequestAsync(HttpMethod.Get, OpenSynchronosFiles.RequestCancelFullPath(downloadFileTransfer[0].DownloadUri, requestId)).ConfigureAwait(false);
                 }
                 catch
                 {

--- a/OpenSynchronos/WebAPI/Files/FileTransferOrchestrator.cs
+++ b/OpenSynchronos/WebAPI/Files/FileTransferOrchestrator.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using OpenSynchronos.MareConfiguration;
 using OpenSynchronos.Services.Mediator;
 using OpenSynchronos.WebAPI.Files.Models;
@@ -28,7 +28,7 @@ public class FileTransferOrchestrator : DisposableMediatorSubscriberBase
         _tokenProvider = tokenProvider;
         _httpClient = httpClient;
         var ver = Assembly.GetExecutingAssembly().GetName().Version;
-        _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("MareSynchronos", ver!.Major + "." + ver!.Minor + "." + ver!.Build));
+        _httpClient.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("OpenSynchronos", ver!.Major + "." + ver!.Minor + "." + ver!.Build));
 
         _availableDownloadSlots = mareConfig.Current.ParallelDownloads;
         _downloadSemaphore = new(_availableDownloadSlots, _availableDownloadSlots);

--- a/OpenSynchronos/WebAPI/Files/FileUploadManager.cs
+++ b/OpenSynchronos/WebAPI/Files/FileUploadManager.cs
@@ -61,7 +61,7 @@ public sealed class FileUploadManager : DisposableMediatorSubscriberBase
     {
         if (!_orchestrator.IsInitialized) throw new InvalidOperationException("FileTransferManager is not initialized");
 
-        await _orchestrator.SendRequestAsync(HttpMethod.Post, MareFiles.ServerFilesDeleteAllFullPath(_orchestrator.FilesCdnUri!)).ConfigureAwait(false);
+        await _orchestrator.SendRequestAsync(HttpMethod.Post, OpenSynchronosFiles.ServerFilesDeleteAllFullPath(_orchestrator.FilesCdnUri!)).ConfigureAwait(false);
     }
 
     public async Task<List<string>> UploadFiles(List<string> hashesToUpload, IProgress<string> progress, CancellationToken? ct = null)
@@ -138,7 +138,7 @@ public sealed class FileUploadManager : DisposableMediatorSubscriberBase
             FileHashes = hashes,
             UIDs = uids
         };
-        var response = await _orchestrator.SendRequestAsync(HttpMethod.Post, MareFiles.ServerFilesFilesSendFullPath(_orchestrator.FilesCdnUri!), filesSendDto, ct).ConfigureAwait(false);
+        var response = await _orchestrator.SendRequestAsync(HttpMethod.Post, OpenSynchronosFiles.ServerFilesFilesSendFullPath(_orchestrator.FilesCdnUri!), filesSendDto, ct).ConfigureAwait(false);
         return await response.Content.ReadFromJsonAsync<List<UploadFileDto>>(cancellationToken: ct).ConfigureAwait(false) ?? [];
     }
 
@@ -223,9 +223,9 @@ public sealed class FileUploadManager : DisposableMediatorSubscriberBase
         streamContent.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
         HttpResponseMessage response;
         if (!munged)
-            response = await _orchestrator.SendRequestStreamAsync(HttpMethod.Post, MareFiles.ServerFilesUploadFullPath(_orchestrator.FilesCdnUri!, fileHash), streamContent, uploadToken).ConfigureAwait(false);
+            response = await _orchestrator.SendRequestStreamAsync(HttpMethod.Post, OpenSynchronosFiles.ServerFilesUploadFullPath(_orchestrator.FilesCdnUri!, fileHash), streamContent, uploadToken).ConfigureAwait(false);
         else
-            response = await _orchestrator.SendRequestStreamAsync(HttpMethod.Post, MareFiles.ServerFilesUploadMunged(_orchestrator.FilesCdnUri!, fileHash), streamContent, uploadToken).ConfigureAwait(false);
+            response = await _orchestrator.SendRequestStreamAsync(HttpMethod.Post, OpenSynchronosFiles.ServerFilesUploadMunged(_orchestrator.FilesCdnUri!, fileHash), streamContent, uploadToken).ConfigureAwait(false);
         Logger.LogDebug("[{hash}] Upload Status: {status}", fileHash, response.StatusCode);
     }
 

--- a/OpenSynchronos/WebAPI/SignalR/ApiController.cs
+++ b/OpenSynchronos/WebAPI/SignalR/ApiController.cs
@@ -19,7 +19,7 @@ using System.Reflection;
 namespace OpenSynchronos.WebAPI;
 
 #pragma warning disable MA0040
-public sealed partial class ApiController : DisposableMediatorSubscriberBase, IMareHubClient
+public sealed partial class ApiController : DisposableMediatorSubscriberBase, IOpenSynchronosHubClient
 {
     public const string MainServer = "Localhost";
     public const string MainServiceUri = "ws://localhost:80";
@@ -134,7 +134,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
             {
                 Logger.LogWarning("Multiple secret keys for current character");
                 _connectionDto = null;
-                Mediator.Publish(new NotificationMessage("Multiple Identical Characters detected", "Your Service configuration has multiple characters with the same name and world set up. Delete the duplicates in the character management to be able to connect to Mare.",
+                Mediator.Publish(new NotificationMessage("Multiple Identical Characters detected", "Your Service configuration has multiple characters with the same name and world set up. Delete the duplicates in the character management to be able to connect to OpenSynchronos.",
                     NotificationType.Error));
                 await StopConnectionAsync(ServerState.MultiChara).ConfigureAwait(false);
                 _connectionCancellationTokenSource?.Cancel();
@@ -157,7 +157,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
             {
                 Logger.LogWarning("Multiple secret keys for current character");
                 _connectionDto = null;
-                Mediator.Publish(new NotificationMessage("Multiple Identical Characters detected", "Your Service configuration has multiple characters with the same name and world set up. Delete the duplicates in the character management to be able to connect to Mare.",
+                Mediator.Publish(new NotificationMessage("Multiple Identical Characters detected", "Your Service configuration has multiple characters with the same name and world set up. Delete the duplicates in the character management to be able to connect to OpenSynchronos.",
                     NotificationType.Error));
                 await StopConnectionAsync(ServerState.MultiChara).ConfigureAwait(false);
                 _connectionCancellationTokenSource?.Cancel();
@@ -233,7 +233,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
 
                 var currentClientVer = Assembly.GetExecutingAssembly().GetName().Version!;
 
-                if (_connectionDto.ServerVersion != IMareHub.ApiVersion)
+                if (_connectionDto.ServerVersion != IOpenSynchronosHub.ApiVersion)
                 {
                     if (_connectionDto.CurrentClientVersion > currentClientVer)
                     {
@@ -276,7 +276,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
                     {
                         Mediator.Publish(new NotificationMessage("Model LOD is enabled",
                             "You have \"Use low-detail models on distant objects (LOD)\" enabled. Having model LOD enabled is known to be a reason to cause " +
-                            "random crashes when loading in or rendering modded pairs. Disabling LOD has a very low performance impact. Disable LOD while using Mare: " +
+                            "random crashes when loading in or rendering modded pairs. Disabling LOD has a very low performance impact. Disable LOD while using OpenSynchronos: " +
                             "Go to XIV Menu -> System Configuration -> Graphics Settings and disable the model LOD option.", NotificationType.Warning, TimeSpan.FromSeconds(15)));
                     }
                 }
@@ -511,7 +511,7 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
         {
             InitializeApiHooks();
             _connectionDto = await GetConnectionDtoAsync(publishConnected: false).ConfigureAwait(false);
-            if (_connectionDto.ServerVersion != IMareHub.ApiVersion)
+            if (_connectionDto.ServerVersion != IOpenSynchronosHub.ApiVersion)
             {
                 await StopConnectionAsync(ServerState.VersionMisMatch).ConfigureAwait(false);
                 return;
@@ -594,3 +594,4 @@ public sealed partial class ApiController : DisposableMediatorSubscriberBase, IM
     }
 }
 #pragma warning restore MA0040
+

--- a/OpenSynchronos/WebAPI/SignalR/HubFactory.cs
+++ b/OpenSynchronos/WebAPI/SignalR/HubFactory.cs
@@ -80,7 +80,7 @@ public class HubFactory : MediatorSubscriberBase
         Logger.LogDebug("Building new HubConnection using transport {transport}", transportType);
 
         _instance = new HubConnectionBuilder()
-            .WithUrl(_serverConfigurationManager.CurrentApiUrl + IMareHub.Path, options =>
+            .WithUrl(_serverConfigurationManager.CurrentApiUrl + IOpenSynchronosHub.Path, options =>
             {
                 options.AccessTokenProvider = () => _tokenProvider.GetOrUpdateToken(ct);
                 options.Transports = transportType;

--- a/OpenSynchronos/WebAPI/SignalR/TokenProvider.cs
+++ b/OpenSynchronos/WebAPI/SignalR/TokenProvider.cs
@@ -63,7 +63,7 @@ public sealed class TokenProvider : IDisposable, IMediatorSubscriber
 
                 if (!_serverManager.CurrentServer.UseOAuth2)
                 {
-                    tokenUri = MareAuth.AuthFullPath(new Uri(_serverManager.CurrentApiUrl
+                    tokenUri = OpenSynchronosAuth.AuthFullPath(new Uri(_serverManager.CurrentApiUrl
                         .Replace("wss://", "https://", StringComparison.OrdinalIgnoreCase)
                         .Replace("ws://", "http://", StringComparison.OrdinalIgnoreCase)));
                     _logger.LogInformation("tokenUri {tokenUri}", tokenUri.ToString());
@@ -78,7 +78,7 @@ public sealed class TokenProvider : IDisposable, IMediatorSubscriber
                 }
                 else
                 {
-                    tokenUri = MareAuth.AuthWithOauthFullPath(new Uri(_serverManager.CurrentApiUrl
+                    tokenUri = OpenSynchronosAuth.AuthWithOauthFullPath(new Uri(_serverManager.CurrentApiUrl
                         .Replace("wss://", "https://", StringComparison.OrdinalIgnoreCase)
                         .Replace("ws://", "http://", StringComparison.OrdinalIgnoreCase)));
                     HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, tokenUri.ToString());
@@ -95,7 +95,7 @@ public sealed class TokenProvider : IDisposable, IMediatorSubscriber
             {
                 _logger.LogDebug("GetNewToken: Renewal");
 
-                tokenUri = MareAuth.RenewTokenFullPath(new Uri(_serverManager.CurrentApiUrl
+                tokenUri = OpenSynchronosAuth.RenewTokenFullPath(new Uri(_serverManager.CurrentApiUrl
                     .Replace("wss://", "https://", StringComparison.OrdinalIgnoreCase)
                     .Replace("ws://", "http://", StringComparison.OrdinalIgnoreCase)));
                 HttpRequestMessage request = new(HttpMethod.Get, tokenUri.ToString());
@@ -254,7 +254,7 @@ public sealed class TokenProvider : IDisposable, IMediatorSubscriber
                 return false;
         }
 
-        var tokenUri = MareAuth.RenewOAuthTokenFullPath(new Uri(currentServer.ServerUri
+        var tokenUri = OpenSynchronosAuth.RenewOAuthTokenFullPath(new Uri(currentServer.ServerUri
             .Replace("wss://", "https://", StringComparison.OrdinalIgnoreCase)
             .Replace("ws://", "http://", StringComparison.OrdinalIgnoreCase)));
         HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Post, tokenUri.ToString());

--- a/OpenSynchronos/packages.lock.json
+++ b/OpenSynchronos/packages.lock.json
@@ -119,9 +119,9 @@
       },
       "SixLabors.ImageSharp": {
         "type": "Direct",
-        "requested": "[3.1.7, )",
-        "resolved": "3.1.7",
-        "contentHash": "9fIOOAsyLFid6qKypM2Iy0Z3Q9yoanV8VoYAHtI2sYGMNKzhvRTjgFDHonIiVe+ANtxIxM6SuqUzj0r91nItpA=="
+        "requested": "[3.1.11, )",
+        "resolved": "3.1.11",
+        "contentHash": "JfPLyigLthuE50yi6tMt7Amrenr/fA31t2CvJyhy/kQmfulIBAqo5T/YFUSRHtuYPXRSaUHygFeh6Qd933EoSw=="
       },
       "SonarAnalyzer.CSharp": {
         "type": "Direct",
@@ -518,7 +518,7 @@
         "resolved": "9.0.3",
         "contentHash": "Ao0iegVONKYVw0eWxJv0ArtMVfkFjgyyYKtUXru6xX5H95flSZWW3QCavD4PAgwpc0ETP38kGHaYbPzSE7sw2w=="
       },
-      "OpenSynchronos.API": {
+      "opensynchronos.api": {
         "type": "Project",
         "dependencies": {
           "MessagePack.Annotations": "[3.1.3, )"


### PR DESCRIPTION
## Overview
Rebrands the plugin to OpenSynchronos to avoid clashes with Mare-based forks. Adds OpenSynchronos IPC labels while retaining Mare labels for compatibility, updates Moodles IPC to V2 endpoints, and bumps ImageSharp to a safe version.

## Changes
- Rebrand/UI/Logs
  - Window system id: OpenSynchronos
  - Localization prefix: OpenSynchronos.Localization.
  - All user-facing “Mare” → “OpenSynchronos”
  - Trace logs: opensynchronos-trace-*.log
  - HTTP UA: OpenSynchronos

- IPC
  - Register OpenSynchronos.* endpoints:
    - LoadMcdf, LoadMcdfAsync, GetHandledAddresses
  - Keep MareSynchronos.* endpoints for compatibility
  - Moodles: adopt …ByPtrV2 endpoints; version check >= 2

- API Surface
  - Use new API names: OpenSynchronosAuth, OpenSynchronosFiles, IOpenSynchronosHub, IOpenSynchronosHubClient
  - Hub Path remains “/mare” (no server changes required)

- Build/Security
  - SixLabors.ImageSharp → 3.1.11 (fixes GHSA-rxmq-m78w-7wmc)
  - Remove duplicate DalamudPackager reference
  - Release/Debug builds pass (warnings only)

## Backward Compatibility
- IPC: Old MareSynchronos.* endpoints still available (transition period).
- Networking: Hub path unchanged (“/mare”).
- No expected behavioral changes; UI labels updated only.

## Validation
- Build Debug/Release
- Settings page: mandatory/optional plugin status indicators
- IPC:
  - MCDF load via both OpenSynchronos.* and MareSynchronos.* names
  - Moodles V2 calls working
- Server connectivity via “/mare”; UA shows “OpenSynchronos”

## Risks/Migration
- Third-party code importing Mare* API types must switch to OpenSynchronos* names (source change).
- Legacy MareSynchronos IPC registrations may be removed in a future major release (deprecation path).

## Follow-ups
- Consider a coordinated migration of hub Path to an OpenSynchronos-specific path in a future major version.
